### PR TITLE
Report superspeed properly on Win7

### DIFF
--- a/UsbDk/FilterDevice.cpp
+++ b/UsbDk/FilterDevice.cpp
@@ -362,6 +362,15 @@ void CUsbDkHubFilterStrategy::RegisterNewChild(PDEVICE_OBJECT PDO)
         return;
     }
 
+#if (NTDDI_VERSION == NTDDI_WIN7)
+    // recheck on Win7, superspeed indication as on Win8 might be not available
+    if (Speed == HighSpeed && DevDescriptor.bcdUSB >= 0x300)
+    {
+        TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_FILTERDEVICE, "%!FUNC! superspeed assigned according to BCD field");
+        Speed = SuperSpeed;
+    }
+#endif
+
     CUsbDkChildDevice::TDescriptorsCache CfgDescriptors(DevDescriptor.bNumConfigurations);
 
     if (!CfgDescriptors.Create())


### PR DESCRIPTION
Win7 with USB 3.0 stack might not report superspeed
the same way as Win8 does. Use bcdUSB field of device
descriptor for that (USB 3.0 device connected to USB 2.x
port usually falls to USB 2 compatible configuration).
Getting the speed from HUB driver via IOCTL is more
complicated.

Signed-off-by: Yuri Benditovich <yuri.benditovich@daynix.com>