### PR TITLE
Populate initial packet length in ISOCH OUT URB

### DIFF
--- a/UsbDk/Urb.cpp
+++ b/UsbDk/Urb.cpp
@@ -71,5 +71,16 @@ NTSTATUS CIsochronousUrb::Create(Direction TransferDirection, PVOID TransferBuff
 
     m_Urb->UrbIsochronousTransfer.TransferBuffer = TransferBuffer;
     m_Urb->UrbIsochronousTransfer.NumberOfPackets = static_cast<ULONG>(NumberOfPackets);
+
+    if (TransferDirection == URB_DIRECTION_OUT)
+    {
+        // initialize Length with initial packet length
+        // USB controller driver may override it (Win7)
+        for (size_t i = 0; i < NumberOfPackets; i++)
+        {
+            m_Urb->UrbIsochronousTransfer.IsoPacket[i].Length = static_cast<ULONG>(PacketSizes[i]);
+        }
+    }
+
     return FillOffsetsArray(NumberOfPackets, PacketSizes, TransferBufferSize);
 }


### PR DESCRIPTION
https://github.com/daynix/UsbDk/issues/66
According to interface definition, the UsbDk shall return
actual length on transfer completion. For isoch OUT transfers
the controller does not return it on respective URB field on
Win10 and the updated WDK documentation states this field is
not used for ISOCH OUT transfers. Current commit populates
the initial packet length in the URB, making the result
consistent on both Win7 and Win10.

Signed-off-by: Yuri Benditovich <yuri.benditovich@daynix.com>