### PR TITLE
Implementation of extended hiding rules

### DIFF
--- a/Documentation/Hider.txt
+++ b/Documentation/Hider.txt
@@ -1,0 +1,83 @@
+Short description of Device Hider feature:
+The interface is described in UsbDkHelperHider.h
+It includes basic and extended interfaces:
+
+1. Basic interface:
+UsbDk_AddPersistentHideRule
+UsbDk_DeletePersistentHideRule
+UsbDk_AddHideRule
+UsbDk_ClearHideRules
+
+Rule structure includes:
+Class
+BCD
+Vendor ID
+Product ID
+Hide specifier (0 or 1), 0 is terminal, 1 continues for next rule
+
+Class describes device class as specified in device descriptor.
+Checkers for these rules do not check classes of interfaces in multifunction devices,
+i.e.
+class match = (device class == rule class) or (rule class == -1)
+
+2. Extended interface
+UsbDk_AddExtendedHideRule
+UsbDk_AddExtendedPersistentHideRule
+UsbDk_DeleteExtendedPersistentHideRule
+
+These API calls receive the same rule structure as basic API and
+an additional parameter 'Rule Type', which can be
+0 (USBDK_HIDER_RULE_DEFAULT) or 1 (USBDK_HIDER_RULE_DETERMINATIVE_TYPES)
+
+Using extended API with USBDK_HIDER_RULE_DEFAULT produces exactly the
+same result as using basic API.
+
+Using USBDK_HIDER_RULE_DETERMINATIVE_TYPES forces different processing
+of hiding rules:
+
+Rule structure includes the same fields:
+Class (bitmask of device types to match)
+BCD
+Vendor ID
+Product ID
+Hide specifier (0 or 1), 0 is terminal, 1 continues for next rule
+
+Device type for each specific device is determined from device class as specified
+in device descriptor and 'class' field in all the interface descriptors of all
+device's configurations.
+
+Supported classes are:
+USB_DEVICE_CLASS_AUDIO (0x1) -> USB_DEVICE_CLASS_AUDIO
+
+USB_DEVICE_CLASS_COMMUNICATIONS(0x2)
+USB_DEVICE_CLASS_CDC_DATA(0xA)
+USB_DEVICE_CLASS_WIRELESS_CONTROLLER(0xE0) -> USB_DEVICE_CLASS_COMMUNICATIONS
+
+USB_DEVICE_CLASS_PRINTER(0x7) -> USB_DEVICE_CLASS_PRINTER
+USB_DEVICE_CLASS_STORAGE(0x8) -> USB_DEVICE_CLASS_STORAGE
+USB_DEVICE_CLASS_VIDEO(0xE) -> USB_DEVICE_CLASS_VIDEO
+USB_DEVICE_CLASS_AUDIO_VIDEO(0x10) -> USB_DEVICE_CLASS_AUDIO, USB_DEVICE_CLASS_VIDEO
+USB_DEVICE_CLASS_HUMAN_INTERFACE(0x3) -> USB_DEVICE_CLASS_HUMAN_INTERFACE
+
+All other classes -> OTHER (31)
+
+Following classes are determinative (if the device belongs to one
+of determinative types, all device types except of
+determinative one are removed from device type bitmask):
+The order of determinative types is:
+USB_DEVICE_CLASS_PRINTER
+USB_DEVICE_CLASS_COMMUNICATIONS
+USB_DEVICE_CLASS_AUDIO
+USB_DEVICE_CLASS_VIDEO
+
+Checkers for these rules check resulting set of device type and
+device types of interfaces in multifunction devices, i.e.
+Class match = (device type bitmask) & (rule class bitmask) != 0
+
+Example of usage:
+Rule.BCD = Rule.VID = Rule.PID = -1;
+Rule.Hide = 1;
+Rule.Class = (1 << USB_DEVICE_CLASS_STORAGE) | (1 << USB_DEVICE_CLASS_PRINTER);
+UsbDk_AddExtendedPersistentHideRule(&Rule, USBDK_HIDER_RULE_DETERMINATIVE_TYPES);
+This call will Hide all the device that determined as being mass storage
+devices or printer devices.

--- a/UsbDk/ControlDevice.cpp
+++ b/UsbDk/ControlDevice.cpp
@@ -911,6 +911,7 @@ private:
 NTSTATUS CUsbDkControlDevice::ReloadPersistentHideRules()
 {
     m_PersistentHideRules.Clear();
+    m_PersistentExtHideRules.Clear();
 
     CHideRulesRegKey RulesKey;
     auto status = RulesKey.Open();

--- a/UsbDk/ControlDevice.cpp
+++ b/UsbDk/ControlDevice.cpp
@@ -815,6 +815,14 @@ public:
             return status;
         }
 
+        DWORD32 val;
+        status = ReadDwordValue(USBDK_HIDE_RULE_TYPE, val);
+        if (!NT_SUCCESS(status))
+        {
+            return status;
+        }
+        Rule.Type = val;
+
         status = ReadDwordMaskValue(USBDK_HIDE_RULE_VID, Rule.VID);
         if (!NT_SUCCESS(status))
         {
@@ -1200,3 +1208,29 @@ void CDriverParamsRegistryPath::Destroy()
 }
 
 CDriverParamsRegistryPath::CAllocatablePath *CDriverParamsRegistryPath::m_Path = nullptr;
+
+NTSTATUS CUsbDkControlDevice::AddHideRule(const USB_DK_HIDE_RULE &UsbDkRule)
+{
+    if (UsbDkRule.Type == USBDK_HIDER_RULE_DEFAULT)
+    {
+        return AddHideRuleToSet(UsbDkRule, m_HideRules);
+    }
+    else if (UsbDkRule.Type == USBDK_HIDER_RULE_DETERMINATIVE_TYPES)
+    {
+        return AddHideRuleToSet(UsbDkRule, m_ExtHideRules);
+    }
+    return STATUS_INVALID_PARAMETER;
+}
+
+NTSTATUS CUsbDkControlDevice::AddPersistentHideRule(const USB_DK_HIDE_RULE &UsbDkRule)
+{
+    if (UsbDkRule.Type == USBDK_HIDER_RULE_DEFAULT)
+    {
+        return AddHideRuleToSet(UsbDkRule, m_PersistentHideRules);
+    }
+    else if (UsbDkRule.Type == USBDK_HIDER_RULE_DETERMINATIVE_TYPES)
+    {
+        return AddHideRuleToSet(UsbDkRule, m_PersistentExtHideRules);
+    }
+    return STATUS_INVALID_PARAMETER;
+}

--- a/UsbDk/ControlDevice.cpp
+++ b/UsbDk/ControlDevice.cpp
@@ -1162,9 +1162,10 @@ NTSTATUS CUsbDkRedirection::CreateRedirectorHandle(HANDLE RequestorProcess, PHAN
     return status;
 }
 
-void CUsbDkHideRule::Dump() const
+LONG CUsbDkHideRule::m_defaultDumpLevel = TRACE_LEVEL_INFORMATION;
+void CUsbDkHideRule::Dump(LONG traceLevel) const
 {
-    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CONTROLDEVICE, "%!FUNC! Hide: %!bool!, C: %08X, V: %08X, P: %08X, BCD: %08X",
+    TraceEvents(traceLevel, TRACE_CONTROLDEVICE, "%!FUNC! Hide: %!bool!, C: %08X, V: %08X, P: %08X, BCD: %08X",
                 m_Hide, m_Class, m_VID, m_PID, m_BCD);
 }
 

--- a/UsbDk/ControlDevice.h
+++ b/UsbDk/ControlDevice.h
@@ -117,6 +117,14 @@ public:
                MatchCharacteristic(m_BCD, Descriptor.bcdDevice);
     }
 
+    bool Match(ULONG UsbClassesBitmask, const USB_DEVICE_DESCRIPTOR &Descriptor) const
+    {
+        return (UsbClassesBitmask & m_Class) &&
+            MatchCharacteristic(m_VID, Descriptor.idVendor) &&
+            MatchCharacteristic(m_PID, Descriptor.idProduct) &&
+            MatchCharacteristic(m_BCD, Descriptor.bcdDevice);
+    }
+
     bool ShouldHide() const
     {
         return m_Hide;
@@ -286,7 +294,8 @@ public:
         return !DontRedirect;
     }
 
-    bool ShouldHide(const USB_DEVICE_DESCRIPTOR &DevDescriptor) const;
+    bool ShouldHideDevice(CUsbDkChildDevice &Device) const;
+    bool ShouldHide(const USB_DK_DEVICE_ID &DevId);
 
     template <typename TDevID>
     void NotifyRedirectionRemoved(const TDevID &Dev) const

--- a/UsbDk/ControlDevice.h
+++ b/UsbDk/ControlDevice.h
@@ -320,6 +320,8 @@ private:
     typedef CWdmSet<CUsbDkHideRule, CLockedAccess, CNonCountingObject> HideRulesSet;
     HideRulesSet m_HideRules;
     HideRulesSet m_PersistentHideRules;
+    HideRulesSet m_ExtHideRules;
+    HideRulesSet m_PersistentExtHideRules;
 
     NTSTATUS AddHideRuleToSet(const USB_DK_HIDE_RULE &UsbDkRule, HideRulesSet &Set);
 

--- a/UsbDk/ControlDevice.h
+++ b/UsbDk/ControlDevice.h
@@ -138,7 +138,7 @@ public:
 
     }
 
-    void Dump() const;
+    void Dump(LONG traceLevel = m_defaultDumpLevel) const;
 
 private:
     bool MatchCharacteristic(ULONG CharacteristicFilter, ULONG CharacteristicValue) const
@@ -152,7 +152,7 @@ private:
     ULONG   m_VID;
     ULONG   m_PID;
     ULONG   m_BCD;
-
+    static  LONG m_defaultDumpLevel;
     DECLARE_CWDMLIST_ENTRY(CUsbDkHideRule);
 };
 

--- a/UsbDk/ControlDevice.h
+++ b/UsbDk/ControlDevice.h
@@ -257,10 +257,8 @@ public:
     NTSTATUS ResetUsbDevice(const USB_DK_DEVICE_ID &DeviceId);
     NTSTATUS AddRedirect(const USB_DK_DEVICE_ID &DeviceId, HANDLE RequestorProcess, PHANDLE ObjectHandle);
 
-    NTSTATUS AddHideRule(const USB_DK_HIDE_RULE &UsbDkRule)
-    { return AddHideRuleToSet(UsbDkRule, m_HideRules); }
-    NTSTATUS AddPersistentHideRule(const USB_DK_HIDE_RULE &UsbDkRule)
-    { return AddHideRuleToSet(UsbDkRule, m_PersistentHideRules); }
+    NTSTATUS AddHideRule(const USB_DK_HIDE_RULE &UsbDkRule);
+    NTSTATUS AddPersistentHideRule(const USB_DK_HIDE_RULE &UsbDkRule);
 
     void ClearHideRules();
 

--- a/UsbDk/FilterDevice.cpp
+++ b/UsbDk/FilterDevice.cpp
@@ -439,7 +439,7 @@ bool CUsbDkHubFilterStrategy::FetchConfigurationDescriptors(CWdmUsbDeviceAccess 
 void CUsbDkHubFilterStrategy::ApplyRedirectionPolicy(CUsbDkChildDevice &Device)
 {
     if (m_ControlDevice->ShouldRedirect(Device) ||
-        m_ControlDevice->ShouldHide(Device.DeviceDescriptor()))
+        m_ControlDevice->ShouldHideDevice(Device))
     {
         if (Device.AttachToDeviceStack())
         {
@@ -646,7 +646,7 @@ bool CUsbDkFilterDevice::CStrategist::SelectStrategy(PDEVICE_OBJECT DevObj)
     }
 
     // Should be hidden -> hider strategy
-    if (m_Strategy->GetControlDevice()->ShouldHide(DevDescr))
+    if (m_Strategy->GetControlDevice()->ShouldHide(ID))
     {
         TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_FILTERDEVICE, "%!FUNC! Assigning hidden USB device strategy");
         m_Strategy->Delete();

--- a/UsbDk/FilterDevice.h
+++ b/UsbDk/FilterDevice.h
@@ -65,8 +65,10 @@ public:
         , m_CfgDescriptors(CfgDescriptors)
         , m_ParentDevice(ParentDevice)
         , m_PDO(PDO)
-    {}
-
+        , m_ClassMaskForExtHider(0)
+    {
+        DetermineDeviceClasses();
+    }
     ULONG ParentID() const;
     PCWCHAR DeviceID() const { return *m_DeviceID->begin(); }
     PCWCHAR InstanceID() const { return *m_InstanceID->begin(); }
@@ -77,6 +79,8 @@ public:
     const USB_DEVICE_DESCRIPTOR &DeviceDescriptor() const
     { return m_DevDescriptor; }
     PDEVICE_OBJECT PDO() const { return m_PDO; }
+    ULONG ClassesBitMask() const
+    { return m_ClassMaskForExtHider; }
 
     bool ConfigurationDescriptor(UCHAR Index, USB_CONFIGURATION_DESCRIPTOR &Buffer, size_t BufferLength)
     {
@@ -107,9 +111,11 @@ private:
     TDescriptorsCache m_CfgDescriptors;
     PDEVICE_OBJECT m_PDO;
     const CUsbDkFilterDevice &m_ParentDevice;
-
+    ULONG m_ClassMaskForExtHider;
     CUsbDkChildDevice(const CUsbDkChildDevice&) = delete;
     CUsbDkChildDevice& operator= (const CUsbDkChildDevice&) = delete;
+
+    void DetermineDeviceClasses();
 
     DECLARE_CWDMLIST_ENTRY(CUsbDkChildDevice);
 };

--- a/UsbDk/HideRulesRegPublic.h
+++ b/UsbDk/HideRulesRegPublic.h
@@ -31,6 +31,7 @@
 #define USBDK_HIDE_RULE_PID             TEXT("PID")
 #define USBDK_HIDE_RULE_BCD             TEXT("BCD")
 #define USBDK_HIDE_RULE_CLASS           TEXT("Class")
+#define USBDK_HIDE_RULE_TYPE            TEXT("Type")
 
 #define USBDK_HIDE_RULES_PATH    TEXT("SYSTEM\\CurrentControlSet\\Services\\") \
                                  USBDK_DRIVER_NAME TEXT("\\")                  \

--- a/UsbDk/UsbDkDataHiderPublic.h
+++ b/UsbDk/UsbDkDataHiderPublic.h
@@ -23,26 +23,16 @@
 
 #pragma once
 
-#include "UsbDkDataHiderPublic.h"
+#define USB_DK_HIDE_RULE_MATCH_ALL ((ULONG64)(-1))
 
-#ifdef __cplusplus
-class USB_DK_HIDE_RULE : public USB_DK_HIDE_RULE_PUBLIC
+typedef struct tag_USB_DK_HIDE_RULE_PUBLIC
 {
-public:
-    USB_DK_HIDE_RULE(PUSB_DK_HIDE_RULE_PUBLIC PublicRule = NULL, ULONG RuleType = USBDK_HIDER_RULE_DEFAULT) :
-        Type(RuleType)
-    {
-        if (PublicRule)
-        {
-            Hide  = PublicRule->Hide;
-            Class = PublicRule->Class;
-            VID   = PublicRule->VID;
-            PID   =  PublicRule->PID;
-            BCD   = PublicRule->BCD;
-        }
-    }
-    ULONG64 Type;
-};
+    ULONG64 Hide;
+    ULONG64 Class;
+    ULONG64 VID;
+    ULONG64 PID;
+    ULONG64 BCD;
+} USB_DK_HIDE_RULE_PUBLIC, *PUSB_DK_HIDE_RULE_PUBLIC;
 
-typedef USB_DK_HIDE_RULE *PUSB_DK_HIDE_RULE;
-#endif
+#define USBDK_HIDER_RULE_DEFAULT                  0
+#define USBDK_HIDER_RULE_DETERMINATIVE_TYPES      1

--- a/UsbDk/stdafx.h
+++ b/UsbDk/stdafx.h
@@ -17,6 +17,17 @@ extern "C"
 
 #if !TARGET_OS_WIN_XP
 #include <UsbSpec.h>
+#else
+#define USB_DEVICE_CLASS_AUDIO                  0x01
+#define USB_DEVICE_CLASS_COMMUNICATIONS         0x02
+#define USB_DEVICE_CLASS_HUMAN_INTERFACE        0x03
+#define USB_DEVICE_CLASS_PRINTER                0x07
+#define USB_DEVICE_CLASS_STORAGE                0x08
+#define USB_DEVICE_CLASS_HUB                    0x09
+#define USB_DEVICE_CLASS_CDC_DATA               0x0A
+#define USB_DEVICE_CLASS_VIDEO                  0x0E
+#define USB_DEVICE_CLASS_AUDIO_VIDEO            0x10
+#define USB_DEVICE_CLASS_WIRELESS_CONTROLLER    0xE0
 #endif
 
 #include <wdfusb.h>

--- a/UsbDkController/UsbDkController.cpp
+++ b/UsbDkController/UsbDkController.cpp
@@ -48,6 +48,7 @@ static void ShowUsage()
     tcout << TEXT("        UsbDkController -H TYPE VID PID BCD Class Hide   - add dynamic hide rule") << endl;
     tcout << TEXT("        UsbDkController -P TYPE VID PID BCD Class Hide   - add persistent hide rule") << endl;
     tcout << TEXT("        UsbDkController -D TYPE VID PID BCD Class Hide   - delete persistent hide rule") << endl;
+    tcout << TEXT("        UsbDkController -Z                               - delete all persistent hide rules") << endl;
     tcout << endl;
     tcout << TEXT("            <VID PID BCD Class> May be specific value or -1 to match all") << endl;
     tcout << TEXT("            <Hide>              Should be 0 or 1, if 0, the rule is terminal") << endl;
@@ -319,6 +320,15 @@ static void Controller_HideDevice(TCHAR *Type, TCHAR *VID, TCHAR *PID, TCHAR *BC
     UsbDk_CloseHiderHandle(hiderHandle);
 }
 
+static int Controller_DeleteAllPersistentHideRules()
+{
+    ULONG done = 0, notDone = 0;
+    auto res = UsbDk_DeleteAllPersistentRules(&done, &notDone);
+    tcout << TEXT("Cleaning persistent rules: done ") << dec << done
+        << TEXT(", not done ") << notDone << endl;
+    return Controller_AnalyzeInstallResult(res, TEXT("Clean persistent hide rules"));
+}
+
 static bool Controller_ChdirToPackageFolder()
 {
     TCHAR PackagePath[MAX_PATH];
@@ -409,6 +419,10 @@ int __cdecl _tmain(int argc, TCHAR* argv[])
                 return -5;
             }
             return Controller_DeletePersistentHideRule(argv[2], argv[3], argv[4], argv[5], argv[6], argv[7]);
+        }
+        else if (_tcscmp(L"-Z", argv[1]) == 0)
+        {
+            return Controller_DeleteAllPersistentHideRules();
         }
         else
         {

--- a/UsbDkHelper/RuleManager.cpp
+++ b/UsbDkHelper/RuleManager.cpp
@@ -16,7 +16,8 @@ static bool operator == (const USB_DK_HIDE_RULE& r1, const USB_DK_HIDE_RULE& r2)
            (r1.PID == r2.PID)     &&
            (r1.BCD == r2.BCD)     &&
            (r1.Class == r2.Class) &&
-           (r1.Hide == r2.Hide);
+           (r1.Hide == r2.Hide)   &&
+           (r1.Type == r2.Type);
 }
 
 DWORD CRulesManager::ReadDword(LPCTSTR RuleName, LPCTSTR ValueName) const
@@ -53,6 +54,7 @@ ULONG64 CRulesManager::ReadBool(LPCTSTR RuleName, LPCTSTR ValueName) const
 
 void CRulesManager::ReadRule(LPCTSTR RuleName, USB_DK_HIDE_RULE &Rule) const
 {
+    Rule.Type  = ReadDword(RuleName, USBDK_HIDE_RULE_TYPE);
     Rule.Hide  = ReadBool(RuleName, USBDK_HIDE_RULE_SHOULD_HIDE);
     Rule.VID   = ReadDwordMask(RuleName, USBDK_HIDE_RULE_VID);
     Rule.PID   = ReadDwordMask(RuleName, USBDK_HIDE_RULE_PID);
@@ -106,6 +108,7 @@ void CRulesManager::AddRule(const USB_DK_HIDE_RULE &Rule)
         throw UsbDkRuleManagerException(TEXT("Failed to create rule key"), ERROR_FUNCTION_FAILED);
     }
 
+    WriteDword(RuleName, USBDK_HIDE_RULE_TYPE, static_cast<ULONG>(Rule.Type));
     WriteDword(RuleName, USBDK_HIDE_RULE_SHOULD_HIDE, static_cast<ULONG>(Rule.Hide));
     WriteDword(RuleName, USBDK_HIDE_RULE_VID, static_cast<ULONG>(Rule.VID));
     WriteDword(RuleName, USBDK_HIDE_RULE_PID, static_cast<ULONG>(Rule.PID));

--- a/UsbDkHelper/RuleManager.cpp
+++ b/UsbDkHelper/RuleManager.cpp
@@ -128,3 +128,20 @@ void CRulesManager::DeleteRule(const USB_DK_HIDE_RULE &Rule)
         }
     }
 }
+
+ULONG CRulesManager::DeleteAllRules(ULONG& notDeleted)
+{
+    ULONG deleted = 0;
+    notDeleted = 0;
+    vector<wstring> subkeys;
+
+    for (const auto &SubKey : m_RegAccess)
+        subkeys.push_back(SubKey);
+
+    while (subkeys.size())
+    {
+        m_RegAccess.DeleteKey(subkeys.front().c_str()) ? deleted++ : notDeleted++;
+        subkeys.erase(subkeys.begin());
+    }
+    return deleted;
+}

--- a/UsbDkHelper/RuleManager.h
+++ b/UsbDkHelper/RuleManager.h
@@ -18,6 +18,7 @@ public:
 
     void AddRule(const USB_DK_HIDE_RULE &Rule);
     void DeleteRule(const USB_DK_HIDE_RULE &Rule);
+    ULONG DeleteAllRules(ULONG& notDeleted);
 private:
     template <typename TFunctor>
     bool FindRule(const USB_DK_HIDE_RULE &Rule, TFunctor Functor);

--- a/UsbDkHelper/UsbDkHelper.cpp
+++ b/UsbDkHelper/UsbDkHelper.cpp
@@ -401,3 +401,29 @@ DLL InstallResult UsbDk_DeletePersistentHideRule(PUSB_DK_HIDE_RULE_PUBLIC Public
 {
     return UsbDk_DeleteExtendedPersistentHideRule(PublicRule, USBDK_HIDER_RULE_DEFAULT);
 }
+
+DLL InstallResult UsbDk_DeleteAllPersistentRules(OUT PULONG pDeleted, OUT PULONG pNotDeleted)
+{
+    try
+    {
+        CRulesManager Manager;
+
+        *pDeleted = *pNotDeleted = 0;
+        *pDeleted = Manager.DeleteAllRules(*pNotDeleted);
+
+        UsbDkDriverAccess driver;
+        driver.UpdateRegistryParameters();
+
+        return *pNotDeleted ? InstallFailure : InstallSuccess;
+    }
+    catch (const UsbDkDriverFileException &e)
+    {
+        printExceptionString(e.what());
+        return InstallSuccessNeedReboot;
+    }
+    catch (const exception &e)
+    {
+        printExceptionString(e.what());
+        return InstallFailure;
+    }
+}

--- a/UsbDkHelper/UsbDkHelper.cpp
+++ b/UsbDkHelper/UsbDkHelper.cpp
@@ -380,14 +380,24 @@ InstallResult ModifyPersistentHideRules(const USB_DK_HIDE_RULE &Rule,
     }
 }
 
+DLL InstallResult UsbDk_AddExtendedPersistentHideRule(PUSB_DK_HIDE_RULE_PUBLIC PublicRule, ULONG Type)
+{
+    USB_DK_HIDE_RULE Rule(PublicRule, Type);
+    return ModifyPersistentHideRules(Rule, &CRulesManager::AddRule);
+}
+
 DLL InstallResult UsbDk_AddPersistentHideRule(PUSB_DK_HIDE_RULE_PUBLIC PublicRule)
 {
-    USB_DK_HIDE_RULE Rule(PublicRule);
-    return ModifyPersistentHideRules(Rule, &CRulesManager::AddRule);
+    return UsbDk_AddExtendedPersistentHideRule(PublicRule, USBDK_HIDER_RULE_DEFAULT);
+}
+
+DLL InstallResult UsbDk_DeleteExtendedPersistentHideRule(PUSB_DK_HIDE_RULE_PUBLIC PublicRule, ULONG Type)
+{
+    USB_DK_HIDE_RULE Rule(PublicRule, Type);
+    return ModifyPersistentHideRules(Rule, &CRulesManager::DeleteRule);
 }
 
 DLL InstallResult UsbDk_DeletePersistentHideRule(PUSB_DK_HIDE_RULE_PUBLIC PublicRule)
 {
-    USB_DK_HIDE_RULE Rule(PublicRule);
-    return ModifyPersistentHideRules(Rule, &CRulesManager::DeleteRule);
+    return UsbDk_DeleteExtendedPersistentHideRule(PublicRule, USBDK_HIDER_RULE_DEFAULT);
 }

--- a/UsbDkHelper/UsbDkHelper.cpp
+++ b/UsbDkHelper/UsbDkHelper.cpp
@@ -305,12 +305,13 @@ HANDLE UsbDk_CreateHiderHandle()
     }
 }
 
-BOOL UsbDk_AddHideRule(HANDLE HiderHandle, PUSB_DK_HIDE_RULE Rule)
+DLL BOOL UsbDk_AddExtendedHideRule(HANDLE HiderHandle, PUSB_DK_HIDE_RULE_PUBLIC PublicRule, ULONG Type)
 {
+    USB_DK_HIDE_RULE Rule(PublicRule, Type);
     try
     {
         auto HiderAccess = unpackHandle<UsbDkHiderAccess>(HiderHandle);
-        HiderAccess->AddHideRule(*Rule);
+        HiderAccess->AddHideRule(Rule);
         return TRUE;
     }
     catch (const exception &e)
@@ -318,6 +319,11 @@ BOOL UsbDk_AddHideRule(HANDLE HiderHandle, PUSB_DK_HIDE_RULE Rule)
         printExceptionString(e.what());
         return FALSE;
     }
+}
+
+BOOL UsbDk_AddHideRule(HANDLE HiderHandle, PUSB_DK_HIDE_RULE_PUBLIC PublicRule)
+{
+    return UsbDk_AddExtendedHideRule(HiderHandle, PublicRule, USBDK_HIDER_RULE_DEFAULT);
 }
 
 BOOL UsbDk_ClearHideRules(HANDLE HiderHandle)
@@ -374,12 +380,14 @@ InstallResult ModifyPersistentHideRules(const USB_DK_HIDE_RULE &Rule,
     }
 }
 
-DLL InstallResult UsbDk_AddPersistentHideRule(PUSB_DK_HIDE_RULE Rule)
+DLL InstallResult UsbDk_AddPersistentHideRule(PUSB_DK_HIDE_RULE_PUBLIC PublicRule)
 {
-    return ModifyPersistentHideRules(*Rule, &CRulesManager::AddRule);
+    USB_DK_HIDE_RULE Rule(PublicRule);
+    return ModifyPersistentHideRules(Rule, &CRulesManager::AddRule);
 }
 
-DLL InstallResult UsbDk_DeletePersistentHideRule(PUSB_DK_HIDE_RULE Rule)
+DLL InstallResult UsbDk_DeletePersistentHideRule(PUSB_DK_HIDE_RULE_PUBLIC PublicRule)
 {
-    return ModifyPersistentHideRules(*Rule, &CRulesManager::DeleteRule);
+    USB_DK_HIDE_RULE Rule(PublicRule);
+    return ModifyPersistentHideRules(Rule, &CRulesManager::DeleteRule);
 }

--- a/UsbDkHelper/UsbDkHelperHider.h
+++ b/UsbDkHelper/UsbDkHelperHider.h
@@ -81,6 +81,28 @@ extern "C" {
     */
     DLL BOOL             UsbDk_AddHideRule(HANDLE HiderHandle, PUSB_DK_HIDE_RULE_PUBLIC Rule);
 
+    /* Add extended rule for detaching USB devices from OS stack.
+    *  The rule definition is the same as for UsbDk_AddHideRule
+    *
+    *  Processing of the rule depend on exact Type parameter
+    *  For existing extended rules see Documentation/Hider.txt
+    *
+    * @params
+    *    IN  - HiderHandle  Handle to UsbDk driver
+    *        - Rule - pointer to hide rule
+    *        - Type - type of the rule
+    *    OUT - None
+    *
+    * @return
+    *  TRUE if function succeeds
+    *
+    * @note
+    * Hide rule stays until HiderHandle is closed, client process exits or
+    * UsbDk_ClearHideRules() called
+    *
+    */
+    DLL BOOL             UsbDk_AddExtendedHideRule(HANDLE HiderHandle, PUSB_DK_HIDE_RULE_PUBLIC Rule, ULONG Type);
+
     /* Clear all hider rules
     *
     * @params
@@ -129,7 +151,31 @@ extern "C" {
     */
     DLL InstallResult    UsbDk_AddPersistentHideRule(PUSB_DK_HIDE_RULE_PUBLIC Rule);
 
-    /* Delete specific persistent hide rule
+    /* Add extended rule for detaching USB devices from OS stack persistently.
+    *  The rule definition is the same as for UsbDk_AddPersistentHideRule
+    *
+    *  Processing of the rule depend on exact Type parameter
+    *  For existing extended rules see Documentation/Hider.txt
+    *
+    * @params
+    *    IN  - Rule - pointer to hide rule
+    *        - Type - type of the rule
+    *    OUT - None
+    *
+    * @return
+    *  Rule installation status
+    *
+    * @note
+    * 1. Persistent rule stays until explicitly deleted by
+    *    UsbDk_DeletePersistentHideRule()
+    * 2. This API requires administrative privileges
+    * 3. For already attached devices the rule will be applied after
+    *    device re-plug or system reboot.
+    *
+    */
+    DLL InstallResult    UsbDk_AddExtendedPersistentHideRule(PUSB_DK_HIDE_RULE_PUBLIC Rule, ULONG Type);
+
+    /* Delete specific persistent hide rule (rule type is default)
     *
     * @params
     *    IN  - Rule - pointer to hide rule
@@ -146,6 +192,25 @@ extern "C" {
     *
     */
     DLL InstallResult    UsbDk_DeletePersistentHideRule(PUSB_DK_HIDE_RULE_PUBLIC Rule);
+
+    /* Delete specific persistent hide rule
+    *
+    * @params
+    *    IN  - Rule - pointer to hide rule
+    *        - Type - type of the rule
+    *    OUT - None
+    *
+    * @return
+    *  Rule removal status
+    *
+    * @note
+    * 1. This API requires administrative privileges
+    * 2. For already attached devices the rule will be applied after
+    *    device re-plug or system reboot.
+    *
+    */
+    DLL InstallResult    UsbDk_DeleteExtendedPersistentHideRule(PUSB_DK_HIDE_RULE_PUBLIC Rule, ULONG Type);
+
 #ifdef __cplusplus
 }
 #endif

--- a/UsbDkHelper/UsbDkHelperHider.h
+++ b/UsbDkHelper/UsbDkHelperHider.h
@@ -35,7 +35,7 @@
 #endif
 #endif
 
-#include "UsbDkDataHider.h"
+#include "UsbDkDataHiderPublic.h"
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -79,7 +79,7 @@ extern "C" {
     * UsbDk_ClearHideRules() called
     *
     */
-    DLL BOOL             UsbDk_AddHideRule(HANDLE HiderHandle, PUSB_DK_HIDE_RULE Rule);
+    DLL BOOL             UsbDk_AddHideRule(HANDLE HiderHandle, PUSB_DK_HIDE_RULE_PUBLIC Rule);
 
     /* Clear all hider rules
     *
@@ -127,12 +127,13 @@ extern "C" {
     *    device re-plug or system reboot.
     *
     */
-    DLL InstallResult    UsbDk_AddPersistentHideRule(PUSB_DK_HIDE_RULE Rule);
+    DLL InstallResult    UsbDk_AddPersistentHideRule(PUSB_DK_HIDE_RULE_PUBLIC Rule);
 
     /* Delete specific persistent hide rule
     *
     * @params
     *    IN  - Rule - pointer to hide rule
+    *        - Type - type of the rule
     *    OUT - None
     *
     * @return
@@ -144,7 +145,7 @@ extern "C" {
     *    device re-plug or system reboot.
     *
     */
-    DLL InstallResult    UsbDk_DeletePersistentHideRule(PUSB_DK_HIDE_RULE Rule);
+    DLL InstallResult    UsbDk_DeletePersistentHideRule(PUSB_DK_HIDE_RULE_PUBLIC Rule);
 #ifdef __cplusplus
 }
 #endif

--- a/UsbDkHelper/UsbDkHelperHider.h
+++ b/UsbDkHelper/UsbDkHelperHider.h
@@ -143,7 +143,7 @@ extern "C" {
     *
     * @note
     * 1. Persistent rule stays until explicitly deleted by
-    *    UsbDk_DeletePersistentHideRule()
+    *    UsbDk_DeletePersistentHideRule or UsbDk_DeleteAllPersistentRules
     * 2. This API requires administrative privileges
     * 3. For already attached devices the rule will be applied after
     *    device re-plug or system reboot.
@@ -167,7 +167,7 @@ extern "C" {
     *
     * @note
     * 1. Persistent rule stays until explicitly deleted by
-    *    UsbDk_DeletePersistentHideRule()
+    *    UsbDk_DeleteExtendedPersistentHideRule() or UsbDk_DeleteAllPersistentRules
     * 2. This API requires administrative privileges
     * 3. For already attached devices the rule will be applied after
     *    device re-plug or system reboot.
@@ -210,6 +210,24 @@ extern "C" {
     *
     */
     DLL InstallResult    UsbDk_DeleteExtendedPersistentHideRule(PUSB_DK_HIDE_RULE_PUBLIC Rule, ULONG Type);
+
+    /* Delete all persistent hide rules
+    *
+    * @params
+    *    IN  - None
+    *    OUT - PULONG pDeleted    - number of deleted rules
+    *          PULONG pNotDeleted - number of not deleted rules
+    *
+    * @return
+    *  Rule removal status
+    *
+    * @note
+    * 1. This API requires administrative privileges
+    * 2. For already attached devices the rules become inactive after
+    *    device re-plug or system reboot.
+    *
+    */
+    DLL InstallResult    UsbDk_DeleteAllPersistentRules(OUT PULONG pDeleted, OUT PULONG pNotDeleted);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Extended hiding rules coexist with existing (basic) hiding rules with following extension:
- taken in account not only USB class specified in device descriptor but also classes mentioned in device interfaces (in case the device is multifunction one)
- there is logic that determines effective device type (based on set of device class and interface classes)
- single extended hide rule contains bitmask of device types to hide and is able to hide several device types at once