### PR TITLE
Issue81

### DIFF
--- a/Tools/Installer/buildmsi.bat
+++ b/Tools/Installer/buildmsi.bat
@@ -9,9 +9,9 @@ pushd ..\..\Install_Debug\x86
 
 del *.msi *.wixobj *.wixpdb
 
-"C:\Program Files (x86)\WiX Toolset v3.8\bin\candle.exe" ..\..\Tools\Installer\UsbDkInstaller.wxs -out UsbDk_Debug.wixobj -dUsbDkVersion=%UsbDkVersion% -dConfig=%DEBUG_CFG%
+"%WIX%bin\candle.exe" ..\..\Tools\Installer\UsbDkInstaller.wxs -out UsbDk_Debug.wixobj -dUsbDkVersion=%UsbDkVersion% -dConfig=%DEBUG_CFG%
 if !ERRORLEVEL! NEQ 0 exit /B 1
-"C:\Program Files (x86)\WiX Toolset v3.8\bin\light.exe" UsbDk_Debug.wixobj -out UsbDk_Debug_%UsbDkVersion%_x86.msi -sw1076
+"%WIX%bin\light.exe" UsbDk_Debug.wixobj -out UsbDk_Debug_%UsbDkVersion%_x86.msi -sw1076
 if !ERRORLEVEL! NEQ 0 exit /B 1
 
 popd
@@ -20,9 +20,9 @@ pushd ..\..\Install_Debug\x64
 
 del *.msi *.wixobj *.wixpdb
 
-"C:\Program Files (x86)\WiX Toolset v3.8\bin\candle.exe" ..\..\Tools\Installer\UsbDkInstaller.wxs -out UsbDk_Debug.wixobj -dUsbDkVersion=%UsbDkVersion% -dConfig=%DEBUG_CFG% -dUsbDk64Bit=1
+"%WIX%bin\candle.exe" ..\..\Tools\Installer\UsbDkInstaller.wxs -out UsbDk_Debug.wixobj -dUsbDkVersion=%UsbDkVersion% -dConfig=%DEBUG_CFG% -dUsbDk64Bit=1
 if !ERRORLEVEL! NEQ 0 exit /B 1
-"C:\Program Files (x86)\WiX Toolset v3.8\bin\light.exe" UsbDk_Debug.wixobj -out UsbDk_Debug_%UsbDkVersion%_x64.msi -sw1076
+"%WIX%bin\light.exe" UsbDk_Debug.wixobj -out UsbDk_Debug_%UsbDkVersion%_x64.msi -sw1076
 if !ERRORLEVEL! NEQ 0 exit /B 1
 
 popd
@@ -31,9 +31,9 @@ pushd ..\..\Install\x86
 
 del *.msi *.wixobj *.wixpdb
 
-"C:\Program Files (x86)\WiX Toolset v3.8\bin\candle.exe" ..\..\Tools\Installer\UsbDkInstaller.wxs -out UsbDk.wixobj -dUsbDkVersion=%UsbDkVersion% -dConfig=Release
+"%WIX%bin\candle.exe" ..\..\Tools\Installer\UsbDkInstaller.wxs -out UsbDk.wixobj -dUsbDkVersion=%UsbDkVersion% -dConfig=Release
 if !ERRORLEVEL! NEQ 0 exit /B 1
-"C:\Program Files (x86)\WiX Toolset v3.8\bin\light.exe" UsbDk.wixobj -out UsbDk_%UsbDkVersion%_x86.msi -sw1076
+"%WIX%bin\light.exe" UsbDk.wixobj -out UsbDk_%UsbDkVersion%_x86.msi -sw1076
 if !ERRORLEVEL! NEQ 0 exit /B 1
 
 popd
@@ -42,9 +42,9 @@ pushd ..\..\Install\x64
 
 del *.msi *.wixobj *.wixpdb
 
-"C:\Program Files (x86)\WiX Toolset v3.8\bin\candle.exe" ..\..\Tools\Installer\UsbDkInstaller.wxs -out UsbDk.wixobj -dUsbDkVersion=%UsbDkVersion% -dConfig=Release -dUsbDk64Bit=1
+"%WIX%bin\candle.exe" ..\..\Tools\Installer\UsbDkInstaller.wxs -out UsbDk.wixobj -dUsbDkVersion=%UsbDkVersion% -dConfig=Release -dUsbDk64Bit=1
 if !ERRORLEVEL! NEQ 0 exit /B 1
-"C:\Program Files (x86)\WiX Toolset v3.8\bin\light.exe" UsbDk.wixobj -out UsbDk_%UsbDkVersion%_x64.msi -sw1076
+"%WIX%bin\light.exe" UsbDk.wixobj -out UsbDk_%UsbDkVersion%_x64.msi -sw1076
 if !ERRORLEVEL! NEQ 0 exit /B 1
 
 popd

--- a/UsbDk/ControlDevice.cpp
+++ b/UsbDk/ControlDevice.cpp
@@ -1081,7 +1081,8 @@ bool CUsbDkControlDevice::NotifyRedirectorAttached(CRegText *DeviceID, CRegText 
 
 bool CUsbDkControlDevice::NotifyRedirectorRemovalStarted(const USB_DK_DEVICE_ID &ID)
 {
-    return m_Redirections.ModifyOne(&ID, [](CUsbDkRedirection *R){ R->NotifyRedirectionRemovalStarted(); });
+    ULONG pid = (ULONG)(ULONG_PTR)PsGetCurrentProcessId();
+    return m_Redirections.ModifyOne(&ID, [](CUsbDkRedirection *R){ R->NotifyRedirectionRemovalStarted(); }, pid);
 }
 
 bool CUsbDkControlDevice::WaitForDetachment(const USB_DK_DEVICE_ID &ID)

--- a/UsbDk/ControlDevice.cpp
+++ b/UsbDk/ControlDevice.cpp
@@ -1110,10 +1110,11 @@ NTSTATUS CUsbDkRedirection::Create(const USB_DK_DEVICE_ID &Id)
     return m_InstanceID.Create(Id.InstanceID);
 }
 
-void CUsbDkRedirection::Dump() const
+void CUsbDkRedirection::Dump(LPCSTR message) const
 {
     TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CONTROLDEVICE,
-                "%!FUNC! Redirect: DevID: %wZ, InstanceID: %wZ",
+                "%!FUNC! %s DevID: %wZ, InstanceID: %wZ",
+                message,
                 m_DeviceID, m_InstanceID);
 }
 

--- a/UsbDk/ControlDevice.cpp
+++ b/UsbDk/ControlDevice.cpp
@@ -1120,6 +1120,12 @@ void CUsbDkRedirection::Dump(LPCSTR message) const
                 m_DeviceID, m_InstanceID);
 }
 
+bool CUsbDkRedirection::MatchProcess(ULONG pid)
+{
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_WDFDEVICE, "%!FUNC! pid 0x%X, owner 0x%X", pid, m_OwnerPid);
+    return pid == m_OwnerPid;
+}
+
 void CUsbDkRedirection::NotifyRedirectorCreated(CUsbDkFilterDevice *RedirectorDevice)
 {
     TraceEvents(TRACE_LEVEL_ERROR, TRACE_WDFDEVICE, "%!FUNC! Redirector created for");
@@ -1209,6 +1215,9 @@ NTSTATUS CUsbDkRedirection::CreateRedirectorHandle(HANDLE RequestorProcess, PHAN
         status = m_RedirectorDevice->CreateUserModeHandle(RequestorProcess, ObjectHandle);
         if (NT_SUCCESS(status))
         {
+            ULONG pid = (ULONG)(ULONG_PTR)PsGetCurrentProcessId();
+            TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_WDFDEVICE, "%!FUNC! done for process 0x%X", pid);
+            m_OwnerPid = pid;
             return status;
         }
 

--- a/UsbDk/ControlDevice.cpp
+++ b/UsbDk/ControlDevice.cpp
@@ -731,6 +731,8 @@ NTSTATUS CUsbDkControlDevice::AddRedirect(const USB_DK_DEVICE_ID &DeviceId, HAND
     {
         return addRes;
     }
+    Redirection->AddRef();
+    CObjHolder<CUsbDkRedirection, CRefCountingDeleter> dereferencer(Redirection);
 
     TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_CONTROLDEVICE, "%!FUNC! Success. New redirections list:");
     m_Redirections.Dump();
@@ -1198,6 +1200,12 @@ NTSTATUS CUsbDkRedirection::CreateRedirectorHandle(HANDLE RequestorProcess, PHAN
 
     do
     {
+        if (IsPreparedForRemove())
+        {
+            TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_WDFDEVICE, "%!FUNC!: device already marked for removal");
+            status = STATUS_DEVICE_REMOVED;
+            break;
+        }
         status = m_RedirectorDevice->CreateUserModeHandle(RequestorProcess, ObjectHandle);
         if (NT_SUCCESS(status))
         {

--- a/UsbDk/ControlDevice.h
+++ b/UsbDk/ControlDevice.h
@@ -190,6 +190,8 @@ public:
     bool IsPreparedForRemove() const
     { return m_RemovalInProgress; }
 
+    bool MatchProcess(ULONG pid);
+
     NTSTATUS WaitForAttachment()
     { return m_RedirectionCreated.Wait(true, -SecondsTo100Nanoseconds(120)); }
 
@@ -216,6 +218,7 @@ private:
     CWdmEvent m_RedirectionCreated;
     CWdmEvent m_RedirectionRemoved;
     CUsbDkFilterDevice *m_RedirectorDevice = nullptr;
+    ULONG m_OwnerPid = 0;
 
     bool m_RemovalInProgress = false;
 

--- a/UsbDk/ControlDevice.h
+++ b/UsbDk/ControlDevice.h
@@ -178,7 +178,7 @@ public:
     bool operator==(const CUsbDkChildDevice &Dev) const;
     bool operator==(const CUsbDkRedirection &Other) const;
 
-    void Dump() const;
+    void Dump(LPCSTR message = " ") const;
 
     void NotifyRedirectorCreated(CUsbDkFilterDevice *RedirectorDevice);
     void NotifyRedirectionRemoved();

--- a/UsbDk/ControlDevice.h
+++ b/UsbDk/ControlDevice.h
@@ -200,6 +200,7 @@ public:
 private:
     ~CUsbDkRedirection()
     {
+        Dump("Deleting ");
         if (m_RedirectorDevice != nullptr)
         {
             m_RedirectorDevice->Release();

--- a/UsbDk/FilterDevice.h
+++ b/UsbDk/FilterDevice.h
@@ -175,6 +175,7 @@ public:
     void SetSerialNumber(ULONG Number)
     { m_SerialNumber = Number; }
 
+    void OnFileCreate(WDFREQUEST Request);
 private:
     ~CUsbDkFilterDevice()
     {

--- a/UsbDk/RedirectorStrategy.cpp
+++ b/UsbDk/RedirectorStrategy.cpp
@@ -630,6 +630,7 @@ void CUsbDkRedirectorStrategy::OnClose()
 {
     USB_DK_DEVICE_ID ID;
     UsbDkFillIDStruct(&ID, *m_DeviceID->begin(), *m_InstanceID->begin());
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_REDIRECTOR, "%!FUNC!");
 
     auto status = m_ControlDevice->RemoveRedirect(ID);
     if (!NT_SUCCESS(status))

--- a/UsbDk/UsbDkUtil.h
+++ b/UsbDk/UsbDkUtil.h
@@ -411,10 +411,18 @@ public:
     }
 
     template <typename TEntryId, typename TModifier>
-    bool ModifyOne(TEntryId *Id, TModifier ModifierFunc)
+    bool ModifyOne(TEntryId *Id, TModifier ModifierFunc, ULONG process = 0)
     {
         CLockedContext<TAccessStrategy> LockedContext(*this);
-        return !m_Objects.ForEachIf([Id](TEntryType *ExistingEntry) { return *ExistingEntry == *Id; },
+        return !m_Objects.ForEachIf([Id,process](TEntryType *ExistingEntry)
+                                    {
+                                        bool match = *ExistingEntry == *Id;
+                                        if (process && match)
+                                        {
+                                            match = ExistingEntry->MatchProcess(process);
+                                        }
+                                        return match;
+                                    },
                                     [&ModifierFunc](TEntryType *Entry) { ModifierFunc(Entry); return false; });
     }
 

--- a/buildAll.bat
+++ b/buildAll.bat
@@ -2,6 +2,7 @@
 
 SETLOCAL EnableExtensions EnableDelayedExpansion
 
+set _f=UsbDk
 if [%1] EQU [MSIONLY] goto BUILD_MSI
 if [%2] EQU [NOSIGN] (SET DEBUG_CFG=Debug_NoSign) ELSE (SET DEBUG_CFG=Debug)
 
@@ -17,16 +18,40 @@ for %%x in (Win7, Win8, Win8.1, Win10, XP) do (
 )
 
 pushd Install
-"C:\Program Files (x86)\Windows Kits\10\bin\x86\tracepdb.exe" -s -o .\UsbDk.tmf
+call :maketmf Release
 if !ERRORLEVEL! NEQ 0 exit /B 1
 popd
 
 pushd Install_Debug
-"C:\Program Files (x86)\Windows Kits\10\bin\x86\tracepdb.exe" -s -o .\UsbDk.tmf
+call :maketmf Debug
 if !ERRORLEVEL! NEQ 0 exit /B 1
 popd
 
 if [%1] EQU [NOMSI] goto NOMSI
+goto BUILD_MSI
+
+:maketmf
+del *.tmf *.mof
+call :make1tmf x64\Win10%1
+call :make1tmf x86\Win10%1
+call :make1tmf x64\Win8.1%1
+call :make1tmf x86\Win8.1%1
+call :make1tmf x64\Win8%1
+call :make1tmf x86\Win8%1
+call :make1tmf x64\Win7%1
+call :make1tmf x86\Win7%1
+call :make1tmf x64\XP%1
+call :make1tmf x86\XP%1
+goto :eof
+
+:make1tmf
+pushd %1
+echo Making TMF in %1
+"C:\Program Files (x86)\Windows Kits\10\bin\x86\tracepdb.exe" -s -o .\%_f%.tmf
+popd
+type %1\%_f%.tmf >> %_f%.tmf
+del %1\%_f%.??f
+goto :eof
 
 :BUILD_MSI
 


### PR DESCRIPTION
Fixes for 2 problem:
1. BSOD on 1.0.21. Inspired by by 3rd party application that opens-closes the redirected device instance (actually of USB device that it handles) - the object destroyed during redirection
2. The same flow cancels the redirection. Fixed by 'owned process' check on file close.
+ Small fix in the build
